### PR TITLE
Issue #8 フリーミアム制御＋サブスク導入

### DIFF
--- a/lib/core/models/subscription_status.dart
+++ b/lib/core/models/subscription_status.dart
@@ -1,0 +1,99 @@
+enum SubscriptionPlan { free, premium }
+
+class SubscriptionStatus {
+  SubscriptionStatus({
+    required this.plan,
+    required this.isActive,
+    required this.entitlementId,
+    required this.syncedAt,
+    this.productId,
+    this.expirationDate,
+  });
+
+  factory SubscriptionStatus.free({DateTime? syncedAt}) => SubscriptionStatus(
+    plan: SubscriptionPlan.free,
+    isActive: false,
+    entitlementId: 'premium',
+    syncedAt: syncedAt ?? DateTime.fromMillisecondsSinceEpoch(0),
+  );
+
+  factory SubscriptionStatus.premium({
+    String entitlementId = 'premium',
+    String? productId,
+    DateTime? expirationDate,
+    DateTime? syncedAt,
+  }) => SubscriptionStatus(
+    plan: SubscriptionPlan.premium,
+    isActive: true,
+    entitlementId: entitlementId,
+    productId: productId,
+    expirationDate: expirationDate,
+    syncedAt: syncedAt ?? DateTime.fromMillisecondsSinceEpoch(0),
+  );
+
+  final SubscriptionPlan plan;
+  final bool isActive;
+  final String entitlementId;
+  final String? productId;
+  final DateTime? expirationDate;
+  final DateTime syncedAt;
+
+  bool get isPremium => plan == SubscriptionPlan.premium && isActive;
+
+  Map<String, dynamic> toJson() => {
+    'plan': plan.name,
+    'is_active': isActive,
+    'entitlement_id': entitlementId,
+    'product_id': productId,
+    'expiration_date': expirationDate?.toIso8601String(),
+    'synced_at': syncedAt.toIso8601String(),
+  };
+
+  factory SubscriptionStatus.fromJson(Map<String, dynamic> json) {
+    final planName = json['plan'] as String? ?? 'free';
+    return SubscriptionStatus(
+      plan: planName == SubscriptionPlan.premium.name
+          ? SubscriptionPlan.premium
+          : SubscriptionPlan.free,
+      isActive: json['is_active'] as bool? ?? false,
+      entitlementId: json['entitlement_id'] as String? ?? 'premium',
+      productId: json['product_id'] as String?,
+      expirationDate: _parseDateTime(json['expiration_date']),
+      syncedAt:
+          _parseDateTime(json['synced_at']) ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  static DateTime? _parseDateTime(Object? value) {
+    if (value is String && value.isNotEmpty) {
+      return DateTime.parse(value);
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is SubscriptionStatus &&
+        other.plan == plan &&
+        other.isActive == isActive &&
+        other.entitlementId == entitlementId &&
+        other.productId == productId &&
+        other.expirationDate == expirationDate &&
+        other.syncedAt == syncedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    plan,
+    isActive,
+    entitlementId,
+    productId,
+    expirationDate,
+    syncedAt,
+  );
+}

--- a/lib/features/ai_suggestion/night_suggestion_page.dart
+++ b/lib/features/ai_suggestion/night_suggestion_page.dart
@@ -1,8 +1,10 @@
 import 'package:dawnshift/core/models/routine_suggestion.dart';
+import 'package:dawnshift/core/models/subscription_status.dart';
 import 'package:dawnshift/features/ai_suggestion/anthropic_client.dart';
 import 'package:dawnshift/features/ai_suggestion/night_suggestion_service.dart';
 import 'package:dawnshift/features/routine/routine_repository.dart';
 import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:dawnshift/features/subscription/subscription_service.dart';
 import 'package:flutter/material.dart';
 
 class NightSuggestionPage extends StatefulWidget {
@@ -11,12 +13,14 @@ class NightSuggestionPage extends StatefulWidget {
     required this.sleepRepository,
     required this.routineRepository,
     required this.anthropicClient,
+    required this.subscriptionService,
     this.now = _now,
   });
 
   final SleepRecordRepository sleepRepository;
   final RoutineRepository routineRepository;
   final AnthropicClient anthropicClient;
+  final SubscriptionService subscriptionService;
   final DateTime Function() now;
 
   static DateTime _now() => DateTime.now();
@@ -27,9 +31,11 @@ class NightSuggestionPage extends StatefulWidget {
 
 class _NightSuggestionPageState extends State<NightSuggestionPage> {
   late final NightSuggestionService _service;
+  SubscriptionStatus? _subscriptionStatus;
   RoutineSuggestionResult? _result;
   String? _message;
   bool _isLoading = false;
+  bool _isPurchasing = false;
 
   @override
   void initState() {
@@ -39,6 +45,18 @@ class _NightSuggestionPageState extends State<NightSuggestionPage> {
       routineRepository: widget.routineRepository,
       anthropicClient: widget.anthropicClient,
     );
+    _loadSubscription();
+  }
+
+  Future<void> _loadSubscription() async {
+    final status = await widget.subscriptionService.getCurrentStatus();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _subscriptionStatus = status;
+    });
   }
 
   Future<void> _generateSuggestion() async {
@@ -88,14 +106,60 @@ class _NightSuggestionPageState extends State<NightSuggestionPage> {
     ).showSnackBar(const SnackBar(content: Text('明日の朝ルーティンに反映しました')));
   }
 
+  Future<void> _purchasePremium() async {
+    setState(() {
+      _isPurchasing = true;
+      _message = null;
+    });
+
+    try {
+      final status = await widget.subscriptionService.purchasePremium();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _subscriptionStatus = status;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _message = '購入の開始に失敗しました。時間をおいて再度お試しください。';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPurchasing = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _restorePurchases() async {
+    final status = await widget.subscriptionService.restorePurchases();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _subscriptionStatus = status;
+      _message = status.isPremium ? '購入状態を復元しました。' : '復元できる購入は見つかりませんでした。';
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    final subscriptionStatus = _subscriptionStatus;
     final suggestion = _result?.suggestion;
     final timeToFirstChunk = _result?.timeToFirstChunk;
 
     return Scaffold(
       appBar: AppBar(title: const Text('今夜のAI提案')),
-      body: ListView(
+      body: subscriptionStatus == null
+          ? const Center(child: CircularProgressIndicator())
+          : subscriptionStatus.isPremium
+          ? ListView(
         padding: const EdgeInsets.all(16),
         children: [
           FilledButton(
@@ -143,6 +207,53 @@ class _NightSuggestionPageState extends State<NightSuggestionPage> {
             ),
           ],
         ],
+      )
+          : ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const _PaywallCard(),
+          const SizedBox(height: 16),
+          FilledButton(
+            key: const Key('purchase-premium'),
+            onPressed: _isPurchasing ? null : _purchasePremium,
+            child: Text(_isPurchasing ? '購入処理中...' : 'プレミアムを開始'),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton(
+            key: const Key('restore-premium'),
+            onPressed: _restorePurchases,
+            child: const Text('購入を復元'),
+          ),
+          if (_message != null) ...[
+            const SizedBox(height: 16),
+            Text(_message!),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PaywallCard extends StatelessWidget {
+  const _PaywallCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Text('AIアドバイスはプレミアム限定です'),
+            SizedBox(height: 12),
+            Text('無料プラン'),
+            Text('睡眠記録・基本ルーティン設定'),
+            SizedBox(height: 12),
+            Text('プレミアムプラン'),
+            Text('AIアドバイス・週次レポート・ルーティン上限解放'),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/routine/routine_repository.dart
+++ b/lib/features/routine/routine_repository.dart
@@ -1,25 +1,44 @@
 import 'package:dawnshift/core/models/routine_item.dart';
 import 'package:dawnshift/core/models/routine_log.dart';
 import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:dawnshift/features/subscription/subscription_service.dart';
 
 export 'package:dawnshift/features/sleep/sleep_record_repository.dart'
     show FakeFirestore, FirestoreInterface;
 
 // ─── RoutineRepository ────────────────────────────────────────
 
+class RoutineLimitExceededException implements Exception {
+  const RoutineLimitExceededException(this.limit);
+
+  final int limit;
+
+  @override
+  String toString() => 'RoutineLimitExceededException: 無料プランの上限は$limit件です。';
+}
+
 class RoutineRepository {
-  RoutineRepository({required FirestoreInterface store, required String uid})
+  RoutineRepository({
+    required FirestoreInterface store,
+    required String uid,
+    SubscriptionService? subscriptionService,
+  })
     : _store = store,
-      _uid = uid;
+      _uid = uid,
+      subscriptionService = subscriptionService;
 
   final FirestoreInterface _store;
   final String _uid;
+  final SubscriptionService? subscriptionService;
+  static const freePlanItemLimit = 5;
 
   String get collectionPath => 'users/$_uid/routines';
   String get routineLogCollectionPath => 'users/$_uid/routine_logs';
 
-  Future<String> add(RoutineItem item) =>
-      _store.add(collectionPath, item.toJson());
+  Future<String> add(RoutineItem item) async {
+    await _enforceFreePlanLimit();
+    return _store.add(collectionPath, item.toJson());
+  }
 
   Future<List<RoutineItem>> findAll() async {
     final docs = await _store.query(collectionPath, orderByField: 'order');
@@ -64,6 +83,23 @@ class RoutineRepository {
     final month = normalized.month.toString().padLeft(2, '0');
     final day = normalized.day.toString().padLeft(2, '0');
     return '${normalized.year}-$month-$day';
+  }
+
+  Future<void> _enforceFreePlanLimit() async {
+    final service = subscriptionService;
+    if (service == null) {
+      return;
+    }
+
+    final status = await service.getCurrentStatus();
+    if (status.isPremium) {
+      return;
+    }
+
+    final existingItems = await findAll();
+    if (existingItems.length >= freePlanItemLimit) {
+      throw const RoutineLimitExceededException(freePlanItemLimit);
+    }
   }
 }
 

--- a/lib/features/routine/routine_settings_page.dart
+++ b/lib/features/routine/routine_settings_page.dart
@@ -117,10 +117,24 @@ class _RoutineSettingsPageState extends State<RoutineSettingsPage> {
       order: item?.order ?? _nextOrder(),
     );
 
-    if (item == null) {
-      await widget.repository.add(routineItem);
-    } else {
-      await widget.repository.update(item.id!, routineItem);
+    try {
+      if (item == null) {
+        await widget.repository.add(routineItem);
+      } else {
+        await widget.repository.update(item.id!, routineItem);
+      }
+    } on RoutineLimitExceededException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '無料プランの上限は${error.limit}件です。プレミアムで解除できます。',
+          ),
+        ),
+      );
+      return;
     }
 
     await _loadItems();
@@ -171,6 +185,8 @@ class _RoutineSettingsPageState extends State<RoutineSettingsPage> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          const _PlanComparisonCard(),
+          const SizedBox(height: 16),
           for (final item in _items)
             Card(
               child: ListTile(
@@ -194,6 +210,31 @@ class _RoutineSettingsPageState extends State<RoutineSettingsPage> {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _PlanComparisonCard extends StatelessWidget {
+  const _PlanComparisonCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Text('無料/有料プラン'),
+            SizedBox(height: 12),
+            Text('無料プラン'),
+            Text('睡眠記録・基本ルーティン設定・ルーティン5件まで'),
+            SizedBox(height: 12),
+            Text('プレミアムプラン'),
+            Text('AIアドバイス・週次レポート・ルーティン無制限'),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/subscription/subscription_service.dart
+++ b/lib/features/subscription/subscription_service.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dawnshift/core/models/subscription_status.dart';
+import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
+import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:purchases_flutter/purchases_flutter.dart' as purchases;
+
+abstract class SubscriptionService {
+  Stream<SubscriptionStatus> get statusChanges;
+  Future<SubscriptionStatus> getCurrentStatus();
+  Future<SubscriptionStatus> refreshStatus();
+  Future<SubscriptionStatus> purchasePremium();
+  Future<SubscriptionStatus> restorePurchases();
+}
+
+class RevenueCatCustomerInfo {
+  const RevenueCatCustomerInfo({
+    required this.entitlementIsActive,
+    this.entitlementId = 'premium',
+    this.productIdentifier,
+    this.expirationDate,
+  });
+
+  final bool entitlementIsActive;
+  final String entitlementId;
+  final String? productIdentifier;
+  final DateTime? expirationDate;
+}
+
+abstract class RevenueCatClient {
+  Future<void> configure({required String apiKey, required String appUserId});
+  Future<RevenueCatCustomerInfo> getCustomerInfo();
+  Future<RevenueCatCustomerInfo> purchasePremium();
+  Future<RevenueCatCustomerInfo> restorePurchases();
+}
+
+class PurchasesRevenueCatClient implements RevenueCatClient {
+  PurchasesRevenueCatClient({this.entitlementId = 'premium'});
+
+  final String entitlementId;
+
+  @override
+  Future<void> configure({required String apiKey, required String appUserId}) async {
+    if (apiKey.isEmpty) {
+      return;
+    }
+
+    final configuration = purchases.PurchasesConfiguration(apiKey)
+      ..appUserID = appUserId;
+    await purchases.Purchases.configure(configuration);
+  }
+
+  @override
+  Future<RevenueCatCustomerInfo> getCustomerInfo() async {
+    final customerInfo = await purchases.Purchases.getCustomerInfo();
+    return _mapCustomerInfo(customerInfo);
+  }
+
+  @override
+  Future<RevenueCatCustomerInfo> purchasePremium() async {
+    final offerings = await purchases.Purchases.getOfferings();
+    final package = offerings.current?.availablePackages.firstOrNull;
+    if (package == null) {
+      throw StateError('RevenueCat の offering が見つかりません。');
+    }
+
+    final result = await purchases.Purchases.purchasePackage(package);
+    return _mapCustomerInfo(result.customerInfo);
+  }
+
+  @override
+  Future<RevenueCatCustomerInfo> restorePurchases() async {
+    final customerInfo = await purchases.Purchases.restorePurchases();
+    return _mapCustomerInfo(customerInfo);
+  }
+
+  RevenueCatCustomerInfo _mapCustomerInfo(purchases.CustomerInfo customerInfo) {
+    final entitlement = customerInfo.entitlements.all[entitlementId];
+    return RevenueCatCustomerInfo(
+      entitlementIsActive: entitlement?.isActive == true,
+      entitlementId: entitlement?.identifier ?? entitlementId,
+      productIdentifier:
+          entitlement?.productIdentifier ??
+          customerInfo.activeSubscriptions.firstOrNull,
+      expirationDate: _parseRevenueCatDate(entitlement?.expirationDate),
+    );
+  }
+
+  DateTime? _parseRevenueCatDate(String? value) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    return DateTime.parse(value);
+  }
+}
+
+class RevenueCatSubscriptionService implements SubscriptionService {
+  RevenueCatSubscriptionService({
+    required FirestoreInterface store,
+    required SharedPreferencesStore preferences,
+    required String uid,
+    required String apiKey,
+    RevenueCatClient? revenueCatClient,
+    this.entitlementId = 'premium',
+  }) : _store = store,
+       _preferences = preferences,
+       _uid = uid,
+       _apiKey = apiKey,
+       _revenueCatClient =
+           revenueCatClient ??
+           PurchasesRevenueCatClient(entitlementId: entitlementId);
+
+  final FirestoreInterface _store;
+  final SharedPreferencesStore _preferences;
+  final String _uid;
+  final String _apiKey;
+  final String entitlementId;
+  final RevenueCatClient _revenueCatClient;
+  final _controller = StreamController<SubscriptionStatus>.broadcast();
+  bool _configured = false;
+
+  String get collectionPath => 'users/$_uid/subscription';
+  String get documentId => 'status';
+  String get cacheKey => 'subscription_status_$_uid';
+
+  @override
+  Stream<SubscriptionStatus> get statusChanges => _controller.stream;
+
+  @override
+  Future<SubscriptionStatus> getCurrentStatus() async {
+    final cached = _readCachedStatus();
+    if (cached != null) {
+      return cached;
+    }
+
+    return refreshStatus();
+  }
+
+  @override
+  Future<SubscriptionStatus> refreshStatus() async {
+    try {
+      await _ensureConfigured();
+      final info = await _revenueCatClient.getCustomerInfo();
+      return _persist(_mapInfo(info));
+    } catch (_) {
+      return _loadFallbackStatus();
+    }
+  }
+
+  @override
+  Future<SubscriptionStatus> purchasePremium() async {
+    await _ensureConfigured();
+    final info = await _revenueCatClient.purchasePremium();
+    return _persist(_mapInfo(info));
+  }
+
+  @override
+  Future<SubscriptionStatus> restorePurchases() async {
+    await _ensureConfigured();
+    final info = await _revenueCatClient.restorePurchases();
+    return _persist(_mapInfo(info));
+  }
+
+  Future<void> _ensureConfigured() async {
+    if (_configured || _apiKey.isEmpty) {
+      _configured = true;
+      return;
+    }
+
+    await _revenueCatClient.configure(apiKey: _apiKey, appUserId: _uid);
+    _configured = true;
+  }
+
+  SubscriptionStatus _mapInfo(RevenueCatCustomerInfo info) {
+    final now = DateTime.now();
+    if (info.entitlementIsActive) {
+      return SubscriptionStatus.premium(
+        entitlementId: info.entitlementId,
+        productId: info.productIdentifier,
+        expirationDate: info.expirationDate,
+        syncedAt: now,
+      );
+    }
+
+    return SubscriptionStatus.free(syncedAt: now);
+  }
+
+  Future<SubscriptionStatus> _persist(SubscriptionStatus status) async {
+    await _preferences.setString(cacheKey, jsonEncode(status.toJson()));
+    try {
+      await _store.set(collectionPath, documentId, status.toJson());
+    } catch (_) {
+      // Firestore SDK 側のオフラインキューに任せる前提のため、UI は継続させる。
+    }
+    _controller.add(status);
+    return status;
+  }
+
+  SubscriptionStatus? _readCachedStatus() {
+    final cached = _preferences.getString(cacheKey);
+    if (cached == null) {
+      return null;
+    }
+
+    return SubscriptionStatus.fromJson(
+      jsonDecode(cached) as Map<String, dynamic>,
+    );
+  }
+
+  Future<SubscriptionStatus> _loadFallbackStatus() async {
+    final cached = _readCachedStatus();
+    if (cached != null) {
+      return cached;
+    }
+
+    final remote = await _store.get(collectionPath, documentId);
+    if (remote != null) {
+      final status = SubscriptionStatus.fromJson(remote);
+      await _preferences.setString(cacheKey, jsonEncode(status.toJson()));
+      return status;
+    }
+
+    return SubscriptionStatus.free();
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import cloud_firestore
+import firebase_auth
+import firebase_core
+import purchases_flutter
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
+  FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
+  FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  PurchasesFlutterPlugin.register(with: registry.registrar(forPlugin: "PurchasesFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -256,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  purchases_flutter:
+    dependency: "direct main"
+    description:
+      name: purchases_flutter
+      sha256: "7608be2dc1f48cf34f15cc5830af256b89d2d7966d5da63788a87a7a8925ff87"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.16.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   cloud_firestore: ^5.4.4
   http: ^1.2.2
   flutter_dotenv: ^5.2.1
+  purchases_flutter: ^9.16.1
 
 dev_dependencies:
   flutter_test:

--- a/test/features/ai_suggestion/night_suggestion_page_test.dart
+++ b/test/features/ai_suggestion/night_suggestion_page_test.dart
@@ -5,8 +5,11 @@ import 'package:dawnshift/features/ai_suggestion/anthropic_client.dart';
 import 'package:dawnshift/features/ai_suggestion/night_suggestion_page.dart';
 import 'package:dawnshift/features/routine/routine_repository.dart';
 import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:dawnshift/core/models/subscription_status.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../subscription/fake_subscription_service.dart';
 
 class FakeAnthropicClient implements AnthropicClient {
   FakeAnthropicClient(this.result);
@@ -35,6 +38,7 @@ void main() {
     late SleepRecordRepository sleepRepository;
     late RoutineRepository routineRepository;
     late AnthropicClient anthropicClient;
+    late FakeSubscriptionService subscriptionService;
 
     setUp(() async {
       sleepRepository = SleepRecordRepository(
@@ -57,6 +61,9 @@ void main() {
           timeToFirstChunk: Duration(milliseconds: 800),
         ),
       );
+      subscriptionService = FakeSubscriptionService(
+        initialStatus: SubscriptionStatus.premium(),
+      );
 
       await sleepRepository.save(
         SleepRecord(
@@ -76,6 +83,7 @@ void main() {
             sleepRepository: sleepRepository,
             routineRepository: routineRepository,
             anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
             now: () => DateTime(2026, 4, 7, 21),
           ),
         ),
@@ -116,6 +124,7 @@ void main() {
             sleepRepository: sleepRepository,
             routineRepository: routineRepository,
             anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
             now: () => DateTime(2026, 4, 7, 21),
           ),
         ),
@@ -126,6 +135,36 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('睡眠記録を1件以上登録すると提案を作成できます'), findsOneWidget);
+    });
+
+    testWidgets('未加入ユーザーにはペイウォールを表示し購入後に提案作成を解放する', (tester) async {
+      subscriptionService = FakeSubscriptionService(
+        initialStatus: SubscriptionStatus.free(),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NightSuggestionPage(
+            sleepRepository: sleepRepository,
+            routineRepository: routineRepository,
+            anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
+            now: () => DateTime(2026, 4, 7, 21),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('AIアドバイスはプレミアム限定です'), findsOneWidget);
+      expect(find.text('無料プラン'), findsOneWidget);
+      expect(find.text('プレミアムプラン'), findsOneWidget);
+      expect(find.byKey(const Key('generate-night-suggestion')), findsNothing);
+
+      await tester.tap(find.byKey(const Key('purchase-premium')));
+      await tester.pumpAndSettle();
+
+      expect(subscriptionService.purchaseCalls, 1);
+      expect(find.byKey(const Key('generate-night-suggestion')), findsOneWidget);
     });
   });
 }

--- a/test/features/routine/routine_pages_test.dart
+++ b/test/features/routine/routine_pages_test.dart
@@ -1,17 +1,28 @@
 import 'package:dawnshift/core/models/routine_item.dart';
 import 'package:dawnshift/core/models/routine_log.dart';
+import 'package:dawnshift/core/models/subscription_status.dart';
 import 'package:dawnshift/features/routine/morning_routine_page.dart';
 import 'package:dawnshift/features/routine/routine_repository.dart';
 import 'package:dawnshift/features/routine/routine_settings_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../subscription/fake_subscription_service.dart';
+
 void main() {
   group('RoutineSettingsPage', () {
     late RoutineRepository repository;
+    late FakeSubscriptionService subscriptionService;
 
     setUp(() {
-      repository = RoutineRepository(store: FakeFirestore(), uid: 'user-123');
+      subscriptionService = FakeSubscriptionService(
+        initialStatus: SubscriptionStatus.free(),
+      );
+      repository = RoutineRepository(
+        store: FakeFirestore(),
+        uid: 'user-123',
+        subscriptionService: subscriptionService,
+      );
     });
 
     testWidgets('デフォルトテンプレートを表示し項目を追加・編集・削除できる', (tester) async {
@@ -24,6 +35,8 @@ void main() {
       expect(find.text('朝食'), findsOneWidget);
       expect(find.text('白湯'), findsOneWidget);
       expect(find.text('読書'), findsOneWidget);
+      expect(find.text('無料プラン'), findsOneWidget);
+      expect(find.text('プレミアムプラン'), findsOneWidget);
 
       await tester.tap(find.byKey(const Key('add-routine-item')));
       await tester.pumpAndSettle();
@@ -40,6 +53,8 @@ void main() {
 
       expect(find.text('日光を浴びる'), findsOneWidget);
 
+      await tester.drag(find.byType(ListView), const Offset(0, -300));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('edit-routine-日光を浴びる')));
       await tester.pumpAndSettle();
       await tester.enterText(
@@ -56,6 +71,8 @@ void main() {
       expect(find.text('深呼吸'), findsOneWidget);
       expect(find.text('日光を浴びる'), findsNothing);
 
+      await tester.drag(find.byType(ListView), const Offset(0, -200));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('delete-routine-深呼吸')));
       await tester.pumpAndSettle();
 
@@ -94,6 +111,42 @@ void main() {
         orderedEquals(['散歩', '白湯', '読書', '瞑想']),
       );
       expect(items.map((item) => item.order), orderedEquals([0, 1, 2, 3]));
+    });
+
+    testWidgets('無料プランで5件に達すると追加時に制限メッセージを表示する', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: RoutineSettingsPage(repository: repository)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('add-routine-item')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('routine-title-field')),
+        '瞑想',
+      );
+      await tester.enterText(
+        find.byKey(const Key('routine-duration-field')),
+        '12',
+      );
+      await tester.tap(find.byKey(const Key('save-routine-item')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('add-routine-item')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('routine-title-field')),
+        '6件目',
+      );
+      await tester.enterText(
+        find.byKey(const Key('routine-duration-field')),
+        '8',
+      );
+      await tester.tap(find.byKey(const Key('save-routine-item')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('無料プランの上限は5件です。プレミアムで解除できます。'), findsOneWidget);
+      expect(find.text('6件目'), findsNothing);
     });
   });
 

--- a/test/features/routine/routine_repository_test.dart
+++ b/test/features/routine/routine_repository_test.dart
@@ -1,17 +1,28 @@
 import 'package:dawnshift/features/routine/routine_repository.dart';
 import 'package:dawnshift/core/models/routine_item.dart';
 import 'package:dawnshift/core/models/routine_log.dart';
+import 'package:dawnshift/core/models/subscription_status.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../subscription/fake_subscription_service.dart';
 
 /// Issue #2: Firestore ルーティン項目 CRUD
 /// 完了条件: ルーティンデータの読み書きができること
 void main() {
   group('RoutineRepository', () {
     late RoutineRepository repository;
+    late FakeSubscriptionService subscriptionService;
     const uid = 'user-123';
 
     setUp(() {
-      repository = RoutineRepository(store: FakeFirestore(), uid: uid);
+      subscriptionService = FakeSubscriptionService(
+        initialStatus: SubscriptionStatus.premium(),
+      );
+      repository = RoutineRepository(
+        store: FakeFirestore(),
+        uid: uid,
+        subscriptionService: subscriptionService,
+      );
     });
 
     // ─── 追加 ───────────────────────────────────────────────────
@@ -106,6 +117,29 @@ void main() {
 
       expect(fetched, log);
       expect(fetched!.completionRate, 0.5);
+    });
+
+    test('無料プランではルーティン項目を5件までしか追加できない', () async {
+      repository = RoutineRepository(
+        store: FakeFirestore(),
+        uid: uid,
+        subscriptionService: FakeSubscriptionService(
+          initialStatus: SubscriptionStatus.free(),
+        ),
+      );
+
+      for (var index = 0; index < 5; index++) {
+        await repository.add(
+          RoutineItem(title: '項目$index', durationMinutes: 5, order: index),
+        );
+      }
+
+      expect(
+        () => repository.add(
+          RoutineItem(title: '6件目', durationMinutes: 5, order: 5),
+        ),
+        throwsA(isA<RoutineLimitExceededException>()),
+      );
     });
   });
 

--- a/test/features/subscription/fake_subscription_service.dart
+++ b/test/features/subscription/fake_subscription_service.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:dawnshift/core/models/subscription_status.dart';
+import 'package:dawnshift/features/subscription/subscription_service.dart';
+
+class FakeSubscriptionService implements SubscriptionService {
+  FakeSubscriptionService({SubscriptionStatus? initialStatus})
+    : _currentStatus = initialStatus ?? SubscriptionStatus.free();
+
+  final _controller = StreamController<SubscriptionStatus>.broadcast();
+  SubscriptionStatus _currentStatus;
+  var purchaseCalls = 0;
+  var restoreCalls = 0;
+  var refreshCalls = 0;
+
+  @override
+  Stream<SubscriptionStatus> get statusChanges => _controller.stream;
+
+  @override
+  Future<SubscriptionStatus> getCurrentStatus() async => _currentStatus;
+
+  @override
+  Future<SubscriptionStatus> refreshStatus() async {
+    refreshCalls += 1;
+    return _currentStatus;
+  }
+
+  @override
+  Future<SubscriptionStatus> purchasePremium() async {
+    purchaseCalls += 1;
+    return setStatus(SubscriptionStatus.premium());
+  }
+
+  @override
+  Future<SubscriptionStatus> restorePurchases() async {
+    restoreCalls += 1;
+    return _currentStatus;
+  }
+
+  Future<SubscriptionStatus> setStatus(SubscriptionStatus status) async {
+    _currentStatus = status;
+    _controller.add(status);
+    return status;
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/test/features/subscription/subscription_service_test.dart
+++ b/test/features/subscription/subscription_service_test.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+
+import 'package:dawnshift/core/models/subscription_status.dart';
+import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
+import 'package:dawnshift/features/routine/routine_repository.dart';
+import 'package:dawnshift/features/subscription/subscription_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeSharedPreferences implements SharedPreferencesStore {
+  final _boolValues = <String, bool>{};
+  final _stringValues = <String, String>{};
+
+  @override
+  bool? getBool(String key) => _boolValues[key];
+
+  @override
+  String? getString(String key) => _stringValues[key];
+
+  @override
+  Future<bool> remove(String key) async {
+    _boolValues.remove(key);
+    _stringValues.remove(key);
+    return true;
+  }
+
+  @override
+  Future<bool> setBool(String key, bool value) async {
+    _boolValues[key] = value;
+    return true;
+  }
+
+  @override
+  Future<bool> setString(String key, String value) async {
+    _stringValues[key] = value;
+    return true;
+  }
+}
+
+class FakeRevenueCatClient implements RevenueCatClient {
+  FakeRevenueCatClient({
+    this.customerInfo = const RevenueCatCustomerInfo(
+      entitlementIsActive: false,
+    ),
+    this.purchaseResult = const RevenueCatCustomerInfo(
+      entitlementIsActive: true,
+    ),
+    this.restoreResult = const RevenueCatCustomerInfo(
+      entitlementIsActive: true,
+    ),
+  });
+
+  RevenueCatCustomerInfo customerInfo;
+  RevenueCatCustomerInfo purchaseResult;
+  RevenueCatCustomerInfo restoreResult;
+  bool throwOnGetCustomerInfo = false;
+  bool configured = false;
+  var purchaseCalls = 0;
+  var restoreCalls = 0;
+
+  @override
+  Future<void> configure({required String apiKey, required String appUserId}) async {
+    configured = true;
+  }
+
+  @override
+  Future<RevenueCatCustomerInfo> getCustomerInfo() async {
+    if (throwOnGetCustomerInfo) {
+      throw Exception('offline');
+    }
+    return customerInfo;
+  }
+
+  @override
+  Future<RevenueCatCustomerInfo> purchasePremium() async {
+    purchaseCalls += 1;
+    return purchaseResult;
+  }
+
+  @override
+  Future<RevenueCatCustomerInfo> restorePurchases() async {
+    restoreCalls += 1;
+    return restoreResult;
+  }
+}
+
+void main() {
+  group('RevenueCatSubscriptionService', () {
+    late FakeFirestore firestore;
+    late FakeSharedPreferences preferences;
+    late FakeRevenueCatClient revenueCatClient;
+    late RevenueCatSubscriptionService service;
+
+    setUp(() {
+      firestore = FakeFirestore();
+      preferences = FakeSharedPreferences();
+      revenueCatClient = FakeRevenueCatClient();
+      service = RevenueCatSubscriptionService(
+        store: firestore,
+        preferences: preferences,
+        uid: 'user-123',
+        apiKey: 'public_test_key',
+        revenueCatClient: revenueCatClient,
+      );
+    });
+
+    test('SDK の状態を取得して Firestore とローカルキャッシュへ同期する', () async {
+      revenueCatClient.customerInfo = RevenueCatCustomerInfo(
+        entitlementIsActive: true,
+        entitlementId: 'premium',
+        productIdentifier: 'monthly_premium',
+      );
+
+      final status = await service.refreshStatus();
+      final remote = await firestore.get(service.collectionPath, service.documentId);
+
+      expect(status.isPremium, isTrue);
+      expect(status.plan, SubscriptionPlan.premium);
+      expect(remote?['plan'], 'premium');
+      expect(remote?['is_active'], isTrue);
+      expect(remote?['product_id'], 'monthly_premium');
+      expect(
+        SubscriptionStatus.fromJson(
+          jsonDecode(preferences.getString(service.cacheKey)!) as Map<String, dynamic>,
+        ),
+        status,
+      );
+    });
+
+    test('SDK に到達できない場合はキャッシュ済みの状態を返す', () async {
+      await preferences.setString(
+        service.cacheKey,
+        jsonEncode(SubscriptionStatus.premium().toJson()),
+      );
+      revenueCatClient.throwOnGetCustomerInfo = true;
+
+      final status = await service.getCurrentStatus();
+
+      expect(status.isPremium, isTrue);
+      expect(status.plan, SubscriptionPlan.premium);
+    });
+
+    test('購入フロー完了後にプレミアム状態へ更新する', () async {
+      revenueCatClient.purchaseResult = RevenueCatCustomerInfo(
+        entitlementIsActive: true,
+        entitlementId: 'premium',
+        productIdentifier: 'annual_premium',
+      );
+
+      final status = await service.purchasePremium();
+
+      expect(revenueCatClient.purchaseCalls, 1);
+      expect(status.isPremium, isTrue);
+      expect(status.productId, 'annual_premium');
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <cloud_firestore/cloud_firestore_plugin_c_api.h>
+#include <firebase_auth/firebase_auth_plugin_c_api.h>
+#include <firebase_core/firebase_core_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  CloudFirestorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
+  FirebaseAuthPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,9 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  cloud_firestore
+  firebase_auth
+  firebase_core
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
closes #8

## 実装内容
- RevenueCat ベースの `SubscriptionService` を追加し、SDK 状態を Firestore とローカルキャッシュへ同期
- `NightSuggestionPage` にペイウォール UI を組み込み、未加入時は AI アドバイスを制限し、購入・復元フローを追加
- `RoutineRepository` に無料プラン 5 件上限を追加し、`RoutineSettingsPage` で無料/有料の差分表示と制限メッセージを追加
- サブスク状態・AI ペイウォール・無料プラン上限のテストを追加

## テスト結果
- `/opt/homebrew/bin/flutter test --reporter expanded`
- 68/68 passed