### PR TITLE
Issue #7: add store submission settings flow

### DIFF
--- a/lib/features/auth/auth_service.dart
+++ b/lib/features/auth/auth_service.dart
@@ -47,6 +47,8 @@ abstract class AuthProvider {
 
   Future<void> signOut();
 
+  Future<void> deleteAccount();
+
   AppUser? get currentUser;
 
   Stream<AppUser?> get authStateChanges;
@@ -54,7 +56,7 @@ abstract class AuthProvider {
 
 class FirebaseAuthProvider implements AuthProvider {
   FirebaseAuthProvider({FirebaseAuth? firebaseAuth})
-      : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance;
+    : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance;
 
   final FirebaseAuth _firebaseAuth;
 
@@ -100,6 +102,16 @@ class FirebaseAuthProvider implements AuthProvider {
   @override
   Future<void> signOut() => _firebaseAuth.signOut();
 
+  @override
+  Future<void> deleteAccount() async {
+    final user = _firebaseAuth.currentUser;
+    if (user == null) {
+      throw StateError('削除対象のユーザーがログインしていません。');
+    }
+
+    await user.delete();
+  }
+
   AppUser? _mapUser(User? user) {
     if (user == null || user.email == null) {
       return null;
@@ -117,7 +129,10 @@ class FirebaseAuthProvider implements AuthProvider {
     return appUser;
   }
 
-  Exception _mapFirebaseAuthException(FirebaseAuthException error, String email) {
+  Exception _mapFirebaseAuthException(
+    FirebaseAuthException error,
+    String email,
+  ) {
     switch (error.code) {
       case 'email-already-in-use':
         return EmailAlreadyInUseException(email);
@@ -127,7 +142,9 @@ class FirebaseAuthProvider implements AuthProvider {
       case 'invalid-credential':
         return const WrongPasswordException();
       default:
-        return Exception('FirebaseAuthException(${error.code}): ${error.message}');
+        return Exception(
+          'FirebaseAuthException(${error.code}): ${error.message}',
+        );
     }
   }
 }
@@ -178,6 +195,18 @@ class FakeAuthProvider implements AuthProvider {
     _currentUser = null;
     _stateController.add(null);
   }
+
+  @override
+  Future<void> deleteAccount() async {
+    final user = _currentUser;
+    if (user == null) {
+      throw StateError('削除対象のユーザーがログインしていません。');
+    }
+
+    _users.remove(user.email);
+    _currentUser = null;
+    _stateController.add(null);
+  }
 }
 
 // ─── AuthService ──────────────────────────────────────────────
@@ -194,14 +223,14 @@ class AuthService {
   Future<AppUser> registerWithEmail({
     required String email,
     required String password,
-  }) =>
-      _provider.registerWithEmail(email: email, password: password);
+  }) => _provider.registerWithEmail(email: email, password: password);
 
   Future<AppUser> signInWithEmail({
     required String email,
     required String password,
-  }) =>
-      _provider.signInWithEmail(email: email, password: password);
+  }) => _provider.signInWithEmail(email: email, password: password);
 
   Future<void> signOut() => _provider.signOut();
+
+  Future<void> deleteAccount() => _provider.deleteAccount();
 }

--- a/lib/features/onboarding/onboarding_app.dart
+++ b/lib/features/onboarding/onboarding_app.dart
@@ -1,12 +1,15 @@
+import 'package:dawnshift/features/auth/auth_service.dart';
 import 'package:dawnshift/core/models/user_profile.dart';
 import 'package:dawnshift/features/onboarding/onboarding_page.dart';
 import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
+import 'package:dawnshift/features/settings/settings_page.dart';
 import 'package:flutter/material.dart';
 
 class OnboardingApp extends StatefulWidget {
   const OnboardingApp({
     super.key,
     required this.repository,
+    required this.authService,
     this.currentBedtimePicker,
     this.currentWakeTimePicker,
     this.idealBedtimePicker,
@@ -14,6 +17,7 @@ class OnboardingApp extends StatefulWidget {
   });
 
   final OnboardingRepository repository;
+  final AuthService authService;
   final TimePickerCallback? currentBedtimePicker;
   final TimePickerCallback? currentWakeTimePicker;
   final TimePickerCallback? idealBedtimePicker;
@@ -71,9 +75,7 @@ class _OnboardingAppState extends State<OnboardingApp> {
   @override
   Widget build(BuildContext context) {
     if (_loading) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
 
     if (_showOnboarding) {
@@ -92,15 +94,21 @@ class _OnboardingAppState extends State<OnboardingApp> {
     return _HomePage(
       profile: _profile,
       onEdit: _openOnboarding,
+      authService: widget.authService,
     );
   }
 }
 
 class _HomePage extends StatelessWidget {
-  const _HomePage({required this.profile, required this.onEdit});
+  const _HomePage({
+    required this.profile,
+    required this.onEdit,
+    required this.authService,
+  });
 
   final UserProfile? profile;
   final VoidCallback onEdit;
+  final AuthService authService;
 
   @override
   Widget build(BuildContext context) {
@@ -121,6 +129,18 @@ class _HomePage extends StatelessWidget {
               key: const Key('edit-onboarding'),
               onPressed: onEdit,
               child: const Text('プロフィールを編集'),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton(
+              key: const Key('open-settings'),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => SettingsPage(authService: authService),
+                  ),
+                );
+              },
+              child: const Text('設定'),
             ),
           ],
         ),

--- a/lib/features/settings/privacy_policy_page.dart
+++ b/lib/features/settings/privacy_policy_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class PrivacyPolicyPage extends StatelessWidget {
+  const PrivacyPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('プライバシーポリシー')),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: const [
+          Text(
+            'Dawnshift は睡眠改善と朝の習慣づくりを支援するため、必要な範囲でデータを取り扱います。',
+            style: TextStyle(fontSize: 16),
+          ),
+          SizedBox(height: 24),
+          _Section(
+            title: '収集するデータ',
+            body: '睡眠記録（就寝・起床時刻）、朝ルーティン、ユーザープロフィールを収集します。',
+          ),
+          _Section(title: 'データの利用目的', body: '収集したデータは、睡眠改善アドバイスのAI処理に利用します。'),
+          _Section(
+            title: '第三者サービスへの送信',
+            body: 'Anthropic API（Claude）へ、睡眠改善アドバイスのAI処理を行うため睡眠データを送信します。',
+          ),
+          _Section(title: '保存先', body: 'データは Firebase / Firestore に保存されます。'),
+          _Section(title: 'データ削除方法', body: 'アカウント削除で全データ削除を行います。'),
+        ],
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.body});
+
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 8),
+          Text(body),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -1,0 +1,124 @@
+import 'package:dawnshift/features/auth/auth_service.dart';
+import 'package:dawnshift/features/settings/privacy_policy_page.dart';
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key, this.authService});
+
+  final AuthService? authService;
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  late final Future<PackageInfo> _packageInfoFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _packageInfoFuture = PackageInfo.fromPlatform();
+  }
+
+  Future<void> _confirmDeleteAccount() async {
+    final authService = widget.authService;
+    if (authService == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('認証情報がないためアカウント削除は利用できません。')),
+      );
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('アカウントを削除しますか？'),
+          content: const Text('この操作は取り消せません。'),
+          actions: [
+            TextButton(
+              key: const Key('cancel-delete-account'),
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              key: const Key('confirm-delete-account'),
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('削除する'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed != true || !mounted) {
+      return;
+    }
+
+    await authService.deleteAccount();
+    if (!mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('アカウントを削除しました。')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('設定')),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          const Text('アプリ情報とプライバシー設定を確認できます。', style: TextStyle(fontSize: 16)),
+          const SizedBox(height: 24),
+          Card(
+            child: ListTile(
+              title: const Text('アプリバージョン'),
+              subtitle: FutureBuilder<PackageInfo>(
+                future: _packageInfoFuture,
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Text('読み込み中...');
+                  }
+
+                  return Text(
+                    '${snapshot.data!.version}+${snapshot.data!.buildNumber}',
+                  );
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: ListTile(
+              key: const Key('open-privacy-policy'),
+              title: const Text('プライバシーポリシー'),
+              subtitle: const Text('収集データと利用目的を確認する'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const PrivacyPolicyPage(),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton.tonal(
+            key: const Key('delete-account'),
+            onPressed: _confirmDeleteAccount,
+            style: FilledButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('アカウントを削除'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,22 +2,22 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
 import 'firebase_options.dart';
+import 'features/auth/auth_service.dart';
 import 'features/onboarding/onboarding_app.dart';
 import 'features/onboarding/onboarding_repository.dart';
 import 'features/sleep/sleep_record_repository.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   runApp(const App());
 }
 
 class App extends StatefulWidget {
-  const App({super.key, this.repository});
+  const App({super.key, this.repository, this.authService});
 
   final OnboardingRepository? repository;
+  final AuthService? authService;
 
   @override
   State<App> createState() => _AppState();
@@ -36,7 +36,8 @@ class _AppState extends State<App> {
 
   Future<OnboardingRepository> _buildRepository() async {
     final localStore = await createSharedPreferencesStore();
-    final profileId = localStore.getString('onboarding_profile_id') ??
+    final profileId =
+        localStore.getString('onboarding_profile_id') ??
         'profile-${DateTime.now().millisecondsSinceEpoch}';
 
     if (localStore.getString('onboarding_profile_id') == null) {
@@ -57,9 +58,7 @@ class _AppState extends State<App> {
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const MaterialApp(
-            home: Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            ),
+            home: Scaffold(body: Center(child: CircularProgressIndicator())),
           );
         }
 
@@ -70,7 +69,12 @@ class _AppState extends State<App> {
               seedColor: const Color(0xFF3C6E71),
             ),
           ),
-          home: OnboardingApp(repository: snapshot.data!),
+          home: OnboardingApp(
+            repository: snapshot.data!,
+            authService:
+                widget.authService ??
+                AuthService(provider: FirebaseAuthProvider()),
+          ),
         );
       },
     );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,11 +8,13 @@ import Foundation
 import cloud_firestore
 import firebase_auth
 import firebase_core
+import package_info_plus
 import purchases_flutter
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PurchasesFlutterPlugin.register(with: registry.registrar(forPlugin: "PurchasesFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -248,6 +256,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -357,6 +381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
 sdks:
   dart: ">=3.11.4 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   http: ^1.2.2
   flutter_dotenv: ^5.2.1
   purchases_flutter: ^9.16.1
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/auth/auth_service_test.dart
+++ b/test/features/auth/auth_service_test.dart
@@ -94,6 +94,28 @@ void main() {
       expect(authService.currentUser, isNull);
     });
 
+    test('アカウント削除後は currentUser が null になり再ログインできない', () async {
+      await authService.registerWithEmail(
+        email: 'delete@example.com',
+        password: 'Password123!',
+      );
+
+      await authService.deleteAccount();
+
+      expect(authService.currentUser, isNull);
+      expect(
+        () => authService.signInWithEmail(
+          email: 'delete@example.com',
+          password: 'Password123!',
+        ),
+        throwsA(isA<UserNotFoundException>()),
+      );
+    });
+
+    test('未ログイン状態でアカウント削除すると StateError を投げる', () {
+      expect(() => authService.deleteAccount(), throwsA(isA<StateError>()));
+    });
+
     // ─── 認証状態 ───────────────────────────────────────────────
 
     test('ログイン済みユーザーの UID が取得できる', () async {

--- a/test/features/onboarding/onboarding_page_test.dart
+++ b/test/features/onboarding/onboarding_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:dawnshift/features/onboarding/onboarding_app.dart';
 import 'package:dawnshift/features/onboarding/onboarding_page.dart';
 import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
+import 'package:dawnshift/features/auth/auth_service.dart';
 import 'package:dawnshift/features/routine/routine_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,14 +39,14 @@ class FakeSharedPreferences implements SharedPreferencesStore {
 Future<TimeOfDay?> _fixedPicker(
   BuildContext context,
   TimeOfDay initialTime,
-) async =>
-    initialTime;
+) async => initialTime;
 
 void main() {
   group('OnboardingPage', () {
     late FakeFirestore firestore;
     late FakeSharedPreferences preferences;
     late OnboardingRepository repository;
+    late AuthService authService;
 
     setUp(() {
       firestore = FakeFirestore();
@@ -55,6 +56,7 @@ void main() {
         preferences: preferences,
         uid: 'user-123',
       );
+      authService = AuthService(provider: FakeAuthProvider());
     });
 
     testWidgets('入力内容を保存して完了できる', (tester) async {
@@ -135,6 +137,7 @@ void main() {
     late FakeFirestore firestore;
     late FakeSharedPreferences preferences;
     late OnboardingRepository repository;
+    late AuthService authService;
 
     setUp(() {
       firestore = FakeFirestore();
@@ -144,6 +147,7 @@ void main() {
         preferences: preferences,
         uid: 'user-123',
       );
+      authService = AuthService(provider: FakeAuthProvider());
     });
 
     testWidgets('初回起動では onboarding を表示し、完了後はホームを表示する', (tester) async {
@@ -151,6 +155,7 @@ void main() {
         MaterialApp(
           home: OnboardingApp(
             repository: repository,
+            authService: authService,
             currentBedtimePicker: (_, __) async =>
                 const TimeOfDay(hour: 23, minute: 15),
             currentWakeTimePicker: (_, __) async =>
@@ -185,7 +190,9 @@ void main() {
 
     testWidgets('スキップした後もホームから再編集できる', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(home: OnboardingApp(repository: repository)),
+        MaterialApp(
+          home: OnboardingApp(repository: repository, authService: authService),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -200,6 +207,24 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('ideal-wake-time-field')), findsOneWidget);
+    });
+
+    testWidgets('ホームから設定画面へ遷移できる', (tester) async {
+      await preferences.setBool(repository.completedKey, true);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: OnboardingApp(repository: repository, authService: authService),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('open-settings')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('open-settings')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('設定'), findsOneWidget);
     });
   });
 }

--- a/test/features/settings/settings_page_test.dart
+++ b/test/features/settings/settings_page_test.dart
@@ -1,0 +1,88 @@
+import 'package:dawnshift/features/auth/auth_service.dart';
+import 'package:dawnshift/features/settings/settings_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  group('SettingsPage', () {
+    late AuthService authService;
+
+    setUp(() async {
+      PackageInfo.setMockInitialValues(
+        appName: 'dawnshift',
+        packageName: 'com.example.dawnshift',
+        version: '1.2.3',
+        buildNumber: '45',
+        buildSignature: '',
+      );
+      final provider = FakeAuthProvider();
+      authService = AuthService(provider: provider);
+      await authService.registerWithEmail(
+        email: 'test@example.com',
+        password: 'Password123!',
+      );
+    });
+
+    testWidgets('アプリバージョンとプライバシーポリシー導線を表示する', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: SettingsPage(authService: authService)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('設定'), findsOneWidget);
+      expect(find.text('アプリバージョン'), findsOneWidget);
+      expect(find.text('1.2.3+45'), findsOneWidget);
+      expect(find.byKey(const Key('open-privacy-policy')), findsOneWidget);
+      expect(find.byKey(const Key('delete-account')), findsOneWidget);
+    });
+
+    testWidgets('プライバシーポリシー画面へ遷移して内容を表示する', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: SettingsPage(authService: authService)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('open-privacy-policy')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('プライバシーポリシー'), findsOneWidget);
+      expect(find.textContaining('睡眠記録（就寝・起床時刻）'), findsOneWidget);
+      expect(find.textContaining('Anthropic API（Claude）'), findsOneWidget);
+      expect(find.textContaining('Firebase / Firestore'), findsOneWidget);
+      expect(find.textContaining('アカウント削除で全データ削除'), findsOneWidget);
+    });
+
+    testWidgets('アカウント削除は確認ダイアログでキャンセルできる', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: SettingsPage(authService: authService)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('delete-account')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('アカウントを削除しますか？'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('cancel-delete-account')));
+      await tester.pumpAndSettle();
+
+      expect(authService.currentUser, isNotNull);
+      expect(find.text('アカウントを削除しますか？'), findsNothing);
+    });
+
+    testWidgets('アカウント削除を確認すると deleteAccount を実行する', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: SettingsPage(authService: authService)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('delete-account')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('confirm-delete-account')));
+      await tester.pumpAndSettle();
+
+      expect(authService.currentUser, isNull);
+      expect(find.text('アカウントを削除しました。'), findsOneWidget);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,6 +5,7 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:dawnshift/features/auth/auth_service.dart';
 import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
 import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
 import 'package:dawnshift/main.dart';
@@ -17,8 +18,11 @@ void main() {
       preferences: _FakePreferences(),
       uid: 'test-user',
     );
+    final authService = AuthService(provider: FakeAuthProvider());
 
-    await tester.pumpWidget(App(repository: repository));
+    await tester.pumpWidget(
+      App(repository: repository, authService: authService),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Onboarding'), findsOneWidget);


### PR DESCRIPTION
closes #7

## 実装内容
- 設定画面を追加し、アプリバージョン表示・プライバシーポリシー導線・アカウント削除導線を実装
- プライバシーポリシー画面を追加し、収集データ・AI 利用目的・Anthropic API 送信・Firebase / Firestore 保存・削除方法を表示
- `AuthService.deleteAccount()` を追加し、ホーム画面から設定画面へ遷移できるようナビゲーションを統合
- `package_info_plus` を追加し、関連ウィジェットテストと認証テストを拡張

## テスト結果
- `flutter test --reporter expanded`
- 75/75 passed