### PR TITLE
[codex] Add home navigation and review page

### DIFF
--- a/lib/features/onboarding/onboarding_app.dart
+++ b/lib/features/onboarding/onboarding_app.dart
@@ -1,8 +1,18 @@
+import 'package:dawnshift/features/ai_suggestion/anthropic_client.dart';
+import 'package:dawnshift/features/ai_suggestion/night_suggestion_page.dart';
 import 'package:dawnshift/features/auth/auth_service.dart';
 import 'package:dawnshift/core/models/user_profile.dart';
 import 'package:dawnshift/features/onboarding/onboarding_page.dart';
 import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
+import 'package:dawnshift/features/review/review_page.dart';
+import 'package:dawnshift/features/routine/morning_routine_page.dart';
+import 'package:dawnshift/features/routine/routine_repository.dart';
+import 'package:dawnshift/features/routine/routine_settings_page.dart';
 import 'package:dawnshift/features/settings/settings_page.dart';
+import 'package:dawnshift/features/sleep/sleep_record_page.dart'
+    show SleepRecordPage;
+import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:dawnshift/features/subscription/subscription_service.dart';
 import 'package:flutter/material.dart';
 
 class OnboardingApp extends StatefulWidget {
@@ -10,6 +20,10 @@ class OnboardingApp extends StatefulWidget {
     super.key,
     required this.repository,
     required this.authService,
+    required this.sleepRepository,
+    required this.routineRepository,
+    required this.anthropicClient,
+    required this.subscriptionService,
     this.currentBedtimePicker,
     this.currentWakeTimePicker,
     this.idealBedtimePicker,
@@ -18,6 +32,10 @@ class OnboardingApp extends StatefulWidget {
 
   final OnboardingRepository repository;
   final AuthService authService;
+  final SleepRecordRepository sleepRepository;
+  final RoutineRepository routineRepository;
+  final AnthropicClient anthropicClient;
+  final SubscriptionService subscriptionService;
   final TimePickerCallback? currentBedtimePicker;
   final TimePickerCallback? currentWakeTimePicker;
   final TimePickerCallback? idealBedtimePicker;
@@ -95,6 +113,10 @@ class _OnboardingAppState extends State<OnboardingApp> {
       profile: _profile,
       onEdit: _openOnboarding,
       authService: widget.authService,
+      sleepRepository: widget.sleepRepository,
+      routineRepository: widget.routineRepository,
+      anthropicClient: widget.anthropicClient,
+      subscriptionService: widget.subscriptionService,
     );
   }
 }
@@ -104,46 +126,127 @@ class _HomePage extends StatelessWidget {
     required this.profile,
     required this.onEdit,
     required this.authService,
+    required this.sleepRepository,
+    required this.routineRepository,
+    required this.anthropicClient,
+    required this.subscriptionService,
   });
 
   final UserProfile? profile;
   final VoidCallback onEdit;
   final AuthService authService;
+  final SleepRecordRepository sleepRepository;
+  final RoutineRepository routineRepository;
+  final AnthropicClient anthropicClient;
+  final SubscriptionService subscriptionService;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('ホーム')),
-      body: Padding(
+      body: ListView(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              profile == null
-                  ? 'まだプロフィールは登録されていません。'
-                  : profile!.toPromptContext(),
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              key: const Key('edit-onboarding'),
-              onPressed: onEdit,
-              child: const Text('プロフィールを編集'),
-            ),
-            const SizedBox(height: 12),
-            OutlinedButton(
-              key: const Key('open-settings'),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => SettingsPage(authService: authService),
-                  ),
-                );
-              },
-              child: const Text('設定'),
-            ),
-          ],
-        ),
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                profile == null
+                    ? 'まだプロフィールは登録されていません。'
+                    : profile!.toPromptContext(),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                key: const Key('edit-onboarding'),
+                onPressed: onEdit,
+                child: const Text('プロフィールを編集'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                key: const Key('open-sleep-record'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) =>
+                          SleepRecordPage(repository: sleepRepository),
+                    ),
+                  );
+                },
+                child: const Text('睡眠記録'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                key: const Key('open-morning-routine'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) =>
+                          MorningRoutinePage(repository: routineRepository),
+                    ),
+                  );
+                },
+                child: const Text('朝ルーティン実行'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                key: const Key('open-routine-settings'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) =>
+                          RoutineSettingsPage(repository: routineRepository),
+                    ),
+                  );
+                },
+                child: const Text('ルーティン設定'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                key: const Key('open-night-suggestion'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => NightSuggestionPage(
+                        sleepRepository: sleepRepository,
+                        routineRepository: routineRepository,
+                        anthropicClient: anthropicClient,
+                        subscriptionService: subscriptionService,
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('AI夜の提案'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                key: const Key('open-review'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => ReviewPage(
+                        sleepRepository: sleepRepository,
+                        routineRepository: routineRepository,
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('振り返り'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                key: const Key('open-settings'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => SettingsPage(authService: authService),
+                    ),
+                  );
+                },
+                child: const Text('設定'),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/review/review_page.dart
+++ b/lib/features/review/review_page.dart
@@ -1,0 +1,127 @@
+import 'package:dawnshift/core/models/routine_log.dart';
+import 'package:dawnshift/core/models/sleep_record.dart';
+import 'package:dawnshift/features/routine/routine_repository.dart';
+import 'package:dawnshift/features/sleep/sleep_record_page.dart';
+import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:flutter/material.dart';
+
+class ReviewPage extends StatefulWidget {
+  const ReviewPage({
+    super.key,
+    required this.sleepRepository,
+    required this.routineRepository,
+    this.now = _now,
+  });
+
+  final SleepRecordRepository sleepRepository;
+  final RoutineRepository routineRepository;
+  final DateTime Function() now;
+
+  static DateTime _now() => DateTime.now();
+
+  @override
+  State<ReviewPage> createState() => _ReviewPageState();
+}
+
+class _ReviewPageState extends State<ReviewPage> {
+  List<SleepRecord> _sleepRecords = const [];
+  List<RoutineLog> _routineLogs = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final sleepRecords = await widget.sleepRepository.findLast7Days(
+      from: widget.now(),
+    );
+    final routineLogs = await widget.routineRepository.getRecentLogs(
+      from: widget.now(),
+    );
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _sleepRecords = sleepRecords;
+      _routineLogs = routineLogs;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('振り返り')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SleepDurationChart(records: _sleepRecords),
+          const SizedBox(height: 16),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('睡眠詳細'),
+                  const SizedBox(height: 12),
+                  if (_sleepRecords.isEmpty)
+                    const Text('まだ記録がありません')
+                  else
+                    for (final record in _sleepRecords) ...[
+                      Text(_formatDate(record.wakeTime)),
+                      Text(
+                        '就寝 ${_formatTime(record.bedtime)} / 起床 ${_formatTime(record.wakeTime)}',
+                      ),
+                      Text('睡眠時間 ${_formatDuration(record.sleepDuration)}'),
+                      const SizedBox(height: 12),
+                    ],
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('ルーティン達成率履歴'),
+                  const SizedBox(height: 12),
+                  if (_routineLogs.isEmpty)
+                    const Text('ルーティン達成率の履歴はまだありません')
+                  else
+                    for (final log in _routineLogs)
+                      ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(_formatDate(log.date)),
+                        trailing: Text(
+                          '${(log.completionRate * 100).round()}%',
+                        ),
+                      ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) => '${date.month}/${date.day}';
+
+  String _formatTime(DateTime date) {
+    final hour = date.hour.toString().padLeft(2, '0');
+    final minute = date.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
+  }
+
+  String _formatDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+    return '${hours}h ${minutes}m';
+  }
+}

--- a/lib/features/routine/routine_repository.dart
+++ b/lib/features/routine/routine_repository.dart
@@ -22,10 +22,9 @@ class RoutineRepository {
     required FirestoreInterface store,
     required String uid,
     SubscriptionService? subscriptionService,
-  })
-    : _store = store,
-      _uid = uid,
-      subscriptionService = subscriptionService;
+  }) : _store = store,
+       _uid = uid,
+       subscriptionService = subscriptionService;
 
   final FirestoreInterface _store;
   final String _uid;
@@ -76,6 +75,22 @@ class RoutineRepository {
     }
 
     return RoutineLog.fromJson(data);
+  }
+
+  Future<List<RoutineLog>> getRecentLogs({required DateTime from}) async {
+    final sevenDaysAgo = DateTime(
+      from.year,
+      from.month,
+      from.day,
+    ).subtract(const Duration(days: 7));
+    final docs = await _store.query(
+      routineLogCollectionPath,
+      afterDate: sevenDaysAgo,
+      limit: 7,
+      orderByField: 'date',
+      descending: true,
+    );
+    return docs.map((doc) => RoutineLog.fromJson(doc.data)).toList();
   }
 
   String _dateKey(DateTime date) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:dawnshift/features/ai_suggestion/anthropic_client.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -7,7 +8,9 @@ import 'features/auth/auth_service.dart';
 import 'features/auth/login_page.dart';
 import 'features/onboarding/onboarding_app.dart';
 import 'features/onboarding/onboarding_repository.dart';
+import 'features/routine/routine_repository.dart';
 import 'features/sleep/sleep_record_repository.dart';
+import 'features/subscription/subscription_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -52,14 +55,26 @@ class _AppState extends State<App> {
     );
   }
 
+  String _anthropicApiKey() {
+    final value = dotenv.isInitialized
+        ? dotenv.env['ANTHROPIC_API_KEY']?.trim()
+        : null;
+    return (value == null || value.isEmpty) ? 'disabled' : value;
+  }
+
+  String _revenueCatApiKey() {
+    if (!dotenv.isInitialized) {
+      return '';
+    }
+    return dotenv.env['REVENUECAT_API_KEY']?.trim() ?? '';
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'dawnshift',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF3C6E71),
-        ),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF3C6E71)),
       ),
       home: StreamBuilder<AppUser?>(
         stream: _authService.authStateChanges,
@@ -82,9 +97,30 @@ class _AppState extends State<App> {
                 );
               }
 
+              final onboardingRepository = repoSnapshot.data!;
+              final firestore =
+                  widget.repository?.firestore ?? FirebaseFirestoreClient();
+              final sleepRepository = SleepRecordRepository(
+                store: firestore,
+                uid: user.uid,
+              );
+              final routineRepository = RoutineRepository(
+                store: firestore,
+                uid: user.uid,
+              );
+
               return OnboardingApp(
-                repository: repoSnapshot.data!,
+                repository: onboardingRepository,
                 authService: _authService,
+                sleepRepository: sleepRepository,
+                routineRepository: routineRepository,
+                anthropicClient: AnthropicApiClient(apiKey: _anthropicApiKey()),
+                subscriptionService: RevenueCatSubscriptionService(
+                  store: firestore,
+                  preferences: onboardingRepository.preferences,
+                  uid: user.uid,
+                  apiKey: _revenueCatApiKey(),
+                ),
               );
             },
           );

--- a/test/features/onboarding/onboarding_page_test.dart
+++ b/test/features/onboarding/onboarding_page_test.dart
@@ -2,9 +2,19 @@ import 'package:dawnshift/features/onboarding/onboarding_app.dart';
 import 'package:dawnshift/features/onboarding/onboarding_page.dart';
 import 'package:dawnshift/features/onboarding/onboarding_repository.dart';
 import 'package:dawnshift/features/auth/auth_service.dart';
+import 'package:dawnshift/features/ai_suggestion/anthropic_client.dart';
+import 'package:dawnshift/features/ai_suggestion/night_suggestion_page.dart';
 import 'package:dawnshift/features/routine/routine_repository.dart';
+import 'package:dawnshift/features/review/review_page.dart';
+import 'package:dawnshift/features/sleep/sleep_record_page.dart';
+import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:dawnshift/core/models/routine_suggestion.dart';
+import 'package:dawnshift/core/models/subscription_status.dart';
+import 'package:dawnshift/features/subscription/subscription_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../subscription/fake_subscription_service.dart';
 
 class FakeSharedPreferences implements SharedPreferencesStore {
   final _boolValues = <String, bool>{};
@@ -41,12 +51,37 @@ Future<TimeOfDay?> _fixedPicker(
   TimeOfDay initialTime,
 ) async => initialTime;
 
+class FakeAnthropicClient implements AnthropicClient {
+  @override
+  String get systemPrompt => 'test';
+
+  @override
+  String buildRequestBody(NightSuggestionRequest request) => '';
+
+  @override
+  String buildUserPrompt(NightSuggestionRequest request) => '';
+
+  @override
+  Future<RoutineSuggestionResult> fetchRoutineSuggestion(
+    NightSuggestionRequest request,
+  ) async {
+    return const RoutineSuggestionResult(
+      suggestion: RoutineSuggestion(targetBedtime: '22:30', routines: []),
+      timeToFirstChunk: Duration(milliseconds: 100),
+    );
+  }
+}
+
 void main() {
   group('OnboardingPage', () {
     late FakeFirestore firestore;
     late FakeSharedPreferences preferences;
     late OnboardingRepository repository;
     late AuthService authService;
+    late SleepRecordRepository sleepRepository;
+    late RoutineRepository routineRepository;
+    late AnthropicClient anthropicClient;
+    late SubscriptionService subscriptionService;
 
     setUp(() {
       firestore = FakeFirestore();
@@ -57,6 +92,15 @@ void main() {
         uid: 'user-123',
       );
       authService = AuthService(provider: FakeAuthProvider());
+      sleepRepository = SleepRecordRepository(
+        store: firestore,
+        uid: 'user-123',
+      );
+      routineRepository = RoutineRepository(store: firestore, uid: 'user-123');
+      anthropicClient = FakeAnthropicClient();
+      subscriptionService = FakeSubscriptionService(
+        initialStatus: SubscriptionStatus.free(),
+      );
     });
 
     testWidgets('入力内容を保存して完了できる', (tester) async {
@@ -138,6 +182,10 @@ void main() {
     late FakeSharedPreferences preferences;
     late OnboardingRepository repository;
     late AuthService authService;
+    late SleepRecordRepository sleepRepository;
+    late RoutineRepository routineRepository;
+    late AnthropicClient anthropicClient;
+    late SubscriptionService subscriptionService;
 
     setUp(() {
       firestore = FakeFirestore();
@@ -148,6 +196,15 @@ void main() {
         uid: 'user-123',
       );
       authService = AuthService(provider: FakeAuthProvider());
+      sleepRepository = SleepRecordRepository(
+        store: firestore,
+        uid: 'user-123',
+      );
+      routineRepository = RoutineRepository(store: firestore, uid: 'user-123');
+      anthropicClient = FakeAnthropicClient();
+      subscriptionService = FakeSubscriptionService(
+        initialStatus: SubscriptionStatus.free(),
+      );
     });
 
     testWidgets('初回起動では onboarding を表示し、完了後はホームを表示する', (tester) async {
@@ -156,6 +213,10 @@ void main() {
           home: OnboardingApp(
             repository: repository,
             authService: authService,
+            sleepRepository: sleepRepository,
+            routineRepository: routineRepository,
+            anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
             currentBedtimePicker: (_, __) async =>
                 const TimeOfDay(hour: 23, minute: 15),
             currentWakeTimePicker: (_, __) async =>
@@ -191,7 +252,14 @@ void main() {
     testWidgets('スキップした後もホームから再編集できる', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: OnboardingApp(repository: repository, authService: authService),
+          home: OnboardingApp(
+            repository: repository,
+            authService: authService,
+            sleepRepository: sleepRepository,
+            routineRepository: routineRepository,
+            anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -214,7 +282,14 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: OnboardingApp(repository: repository, authService: authService),
+          home: OnboardingApp(
+            repository: repository,
+            authService: authService,
+            sleepRepository: sleepRepository,
+            routineRepository: routineRepository,
+            anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -225,6 +300,61 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('設定'), findsOneWidget);
+    });
+
+    testWidgets('ホームから各機能画面へ遷移できる', (tester) async {
+      await preferences.setBool(repository.completedKey, true);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: OnboardingApp(
+            repository: repository,
+            authService: authService,
+            sleepRepository: sleepRepository,
+            routineRepository: routineRepository,
+            anthropicClient: anthropicClient,
+            subscriptionService: subscriptionService,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('open-sleep-record')));
+      await tester.pumpAndSettle();
+      expect(find.text('睡眠記録'), findsOneWidget);
+      expect(find.byType(SleepRecordPage), findsOneWidget);
+
+      Navigator.of(tester.element(find.byType(SleepRecordPage))).pop();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('open-morning-routine')));
+      await tester.pumpAndSettle();
+      expect(find.text('今朝のルーティン'), findsOneWidget);
+
+      Navigator.of(tester.element(find.text('今朝のルーティン'))).pop();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('open-routine-settings')));
+      await tester.pumpAndSettle();
+      expect(find.text('朝ルーティン設定'), findsOneWidget);
+
+      Navigator.of(tester.element(find.text('朝ルーティン設定'))).pop();
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -300));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('open-night-suggestion')));
+      await tester.pumpAndSettle();
+      expect(find.text('今夜のAI提案'), findsOneWidget);
+      expect(find.byType(NightSuggestionPage), findsOneWidget);
+
+      Navigator.of(tester.element(find.byType(NightSuggestionPage))).pop();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('open-review')));
+      await tester.pumpAndSettle();
+      expect(find.text('振り返り'), findsOneWidget);
+      expect(find.byType(ReviewPage), findsOneWidget);
     });
   });
 }

--- a/test/features/review/review_page_test.dart
+++ b/test/features/review/review_page_test.dart
@@ -1,0 +1,92 @@
+import 'package:dawnshift/core/models/routine_log.dart';
+import 'package:dawnshift/core/models/sleep_record.dart';
+import 'package:dawnshift/features/review/review_page.dart';
+import 'package:dawnshift/features/routine/routine_repository.dart';
+import 'package:dawnshift/features/sleep/sleep_record_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ReviewPage', () {
+    late FakeFirestore firestore;
+    late SleepRecordRepository sleepRepository;
+    late RoutineRepository routineRepository;
+    final now = DateTime(2026, 4, 9, 8);
+
+    setUp(() {
+      firestore = FakeFirestore();
+      sleepRepository = SleepRecordRepository(
+        store: firestore,
+        uid: 'user-123',
+      );
+      routineRepository = RoutineRepository(store: firestore, uid: 'user-123');
+    });
+
+    Future<void> pumpPage(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReviewPage(
+            sleepRepository: sleepRepository,
+            routineRepository: routineRepository,
+            now: () => now,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('直近7日分の睡眠グラフとルーティン達成率履歴を表示する', (tester) async {
+      await sleepRepository.save(
+        SleepRecord(
+          bedtime: DateTime(2026, 4, 8, 23, 0),
+          wakeTime: DateTime(2026, 4, 9, 7, 0),
+        ),
+      );
+      await sleepRepository.save(
+        SleepRecord(
+          bedtime: DateTime(2026, 4, 7, 22, 30),
+          wakeTime: DateTime(2026, 4, 8, 6, 30),
+        ),
+      );
+      await routineRepository.saveRoutineLog(
+        RoutineLog(
+          date: DateTime(2026, 4, 9),
+          completedItemIds: const ['a', 'b', 'c'],
+          totalItems: 4,
+        ),
+      );
+      await routineRepository.saveRoutineLog(
+        RoutineLog(
+          date: DateTime(2026, 4, 8),
+          completedItemIds: const ['a'],
+          totalItems: 2,
+        ),
+      );
+
+      await pumpPage(tester);
+
+      expect(find.text('過去7日間の睡眠時間'), findsOneWidget);
+      expect(find.byKey(const Key('sleep-duration-chart')), findsOneWidget);
+      expect(find.byKey(const Key('sleep-bar-0')), findsOneWidget);
+      expect(find.byKey(const Key('sleep-bar-1')), findsOneWidget);
+      expect(find.text('就寝 23:00 / 起床 07:00'), findsOneWidget);
+      expect(find.text('睡眠時間 8h 0m'), findsNWidgets(2));
+      expect(find.text('ルーティン達成率履歴'), findsOneWidget);
+      expect(find.text('4/9'), findsWidgets);
+      expect(find.text('75%'), findsOneWidget);
+
+      await tester.drag(find.byType(ListView), const Offset(0, -300));
+      await tester.pumpAndSettle();
+
+      expect(find.text('4/8'), findsWidgets);
+      expect(find.text('50%'), findsOneWidget);
+    });
+
+    testWidgets('記録がない場合は空状態を表示する', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text('まだ記録がありません'), findsNWidgets(2));
+      expect(find.text('ルーティン達成率の履歴はまだありません'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/routine/routine_repository_test.dart
+++ b/test/features/routine/routine_repository_test.dart
@@ -119,6 +119,39 @@ void main() {
       expect(fetched!.completionRate, 0.5);
     });
 
+    test('直近7日分の完了率ログを新しい順で取得できる', () async {
+      await repository.saveRoutineLog(
+        RoutineLog(
+          date: DateTime(2026, 4, 1),
+          completedItemIds: const ['a'],
+          totalItems: 2,
+        ),
+      );
+      await repository.saveRoutineLog(
+        RoutineLog(
+          date: DateTime(2026, 4, 8),
+          completedItemIds: const ['a', 'b', 'c'],
+          totalItems: 4,
+        ),
+      );
+      await repository.saveRoutineLog(
+        RoutineLog(
+          date: DateTime(2026, 4, 9),
+          completedItemIds: const ['a'],
+          totalItems: 4,
+        ),
+      );
+
+      final logs = await repository.getRecentLogs(
+        from: DateTime(2026, 4, 9, 22),
+      );
+
+      expect(logs.map((log) => log.date), [
+        DateTime(2026, 4, 9),
+        DateTime(2026, 4, 8),
+      ]);
+    });
+
     test('無料プランではルーティン項目を5件までしか追加できない', () async {
       repository = RoutineRepository(
         store: FakeFirestore(),


### PR DESCRIPTION
## 実装内容
- ホーム画面に睡眠記録、朝ルーティン実行、ルーティン設定、AI夜の提案、振り返りへの導線を追加
- `ReviewPage` を追加し、直近7日分の睡眠グラフと睡眠詳細、ルーティン達成率履歴を表示
- `RoutineRepository.getRecentLogs()` を追加し、振り返り画面とテストから直近7日分の達成率ログを取得可能にした
- アプリ起動時にホーム画面へ必要な Repository / Service を注入するよう `main.dart` を更新
- ホーム導線、振り返り画面、達成率ログ取得のテストを追加

## テスト結果
- `flutter test --reporter expanded`
- 80/80 passed